### PR TITLE
Fix manifest validation by updating AppDomain and SupportUrl to organ…

### DIFF
--- a/dist/manifest.xml
+++ b/dist/manifest.xml
@@ -15,7 +15,7 @@
   <HighResolutionIconUrl DefaultValue="https://octagonai.github.io/octagon-excel-functions/assets/icon-64.png"/>
   <SupportUrl DefaultValue="https://octagonai.github.io/octagon-excel-functions/"/>
   <AppDomains>
-    <AppDomain>https://octagonai.github.io/</AppDomain>
+    <AppDomain>https://octagonai.github.io/octagon-excel-functions/</AppDomain>
   </AppDomains>
   <Hosts>
     <Host Name="Workbook"/>

--- a/manifest.xml
+++ b/manifest.xml
@@ -13,9 +13,9 @@
   <Description DefaultValue="Access real-time market intelligence and financial data directly in Excel with Octagon AI agents." />
   <IconUrl DefaultValue="https://octagonai.github.io/octagon-excel-functions/assets/icon-32.png"/>
   <HighResolutionIconUrl DefaultValue="https://octagonai.github.io/octagon-excel-functions/assets/icon-64.png"/>
-  <SupportUrl DefaultValue="https://octagonai.github.io/octagon-excel-functions/"/>
+  <SupportUrl DefaultValue="https://www.octagonai.co"/>
   <AppDomains>
-    <AppDomain>https://octagonai.github.io/</AppDomain>
+    <AppDomain>https://www.octagonai.co</AppDomain>
   </AppDomains>
   <Hosts>
     <Host Name="Workbook"/>


### PR DESCRIPTION
…ization domain

- Change AppDomain from GitHub Pages URL to https://www.octagonai.co
- Change SupportUrl from GitHub Pages URL to https://www.octagonai.co
- Resolve Office manifest validation error about invalid AppDomain URLs
- Align production manifest with local manifest domain configuration
- Maintains GitHub Pages hosting for add-in files while using proper business domain for validation

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- Chores
  - Updated the add-in’s public support link to https://www.octagonai.co, so in-app help now directs to the new website.
  - Aligned the add-in’s trusted domain with https://www.octagonai.co to match the new web presence.
  - Users may need to ensure network/browser settings allow the new domain; support resources and links will now resolve to the updated site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->